### PR TITLE
fix: Redirecting to the specific section on navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,9 +19,9 @@
                     <ul id="navbar">
                         <li title="Login"><a href="choose-file.html">Login</a></li>
                         <li title="Contact Us"><a href="./contact-us.html">Contact Us</a></li>
-                        <li title="Our Services"><a href="">Services</a></li>
-                        <li title="About Us"><a href="">About</a></li>
-                        <li title="Main Page"><a href="">Home</a></li>
+                        <li title="Our Services"><a href="#services">Services</a></li>
+                        <li title="About Us"><a href="#about_show">About</a></li>
+                        <li title="Main Page"><a href="#">Home</a></li>
                     </ul>
                 </nav>
             </div>
@@ -61,7 +61,7 @@
     </header>
 
     <!-- about us section  -->
-    <section>
+    <section id="about_show">
         <div class="about show">
             <h2>About Us</h2>
         </div>
@@ -98,7 +98,7 @@
             </div>
             <div class="buttons">
                 <button id="prev">
-                    <</button>
+                    </button>
                         <button id="next">></button>
             </div>
             <ul class="dots">
@@ -204,6 +204,7 @@
             </div>
         </section>
         <!-- boxes section  -->
+         <section id="services">
         <h3>Top Services</h3>
         <div class="all-boxes">
             <div class="box show hidden">
@@ -258,6 +259,7 @@
                     vel in!</p>
             </div>
         </div>
+    </section>
     </main>
 
     <main>

--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,7 @@
             </div>
             <div class="buttons">
                 <button id="prev">
-                    </button>
+                    <</button>
                         <button id="next">></button>
             </div>
             <ul class="dots">


### PR DESCRIPTION
Fixed issue: #42 
Resolved an issue where clicking on the navigation links (e.g., Services, About) would not navigate to the correct section of the page. The problem was due to improper handling of anchor links or missing section IDs.