### PR TITLE
Refactor: Move Hardcoded Credentials to .env File

### DIFF
--- a/file_upload/form_db.js
+++ b/file_upload/form_db.js
@@ -4,14 +4,21 @@ const {decodeAccessToken}=require('../login-system/token')
 const app = express();
 app.use(express.json());
 
+const DB_HOST = process.env.DB_HOST
+const DB_USER = process.env.DB_USER
+const DB_PASSWORD = process.env.DB_PASSWORD
+const DB_DATABASE = process.env.DB_DATABASE
+const DB_PORT = process.env.DB_PORT
+
 const db = mysql.createPool({
-    host: '127.0.0.1',
-    user: 'user',
-    password: 'Ha@96168737',
-    database: 'user_DB',
-    port: '3306'
- })
- 
+    connectionLimit: 100,
+    host: DB_HOST,
+    user: DB_USER,
+    password: DB_PASSWORD,
+    database: DB_DATABASE,
+    port: DB_PORT
+})
+
 const info=(req,res)=>{
     const decodedtoken = decodeAccessToken(req.headers.authorization);
     if (!decodedtoken || !decodedtoken.user) {

--- a/file_upload/upload.js
+++ b/file_upload/upload.js
@@ -5,13 +5,21 @@ const destination = path.resolve(__dirname, 'uploads/');
 const {decodeAccessToken}=require('../login-system/token')
 const mysql = require('mysql')
 
+
+const DB_HOST = process.env.DB_HOST
+const DB_USER = process.env.DB_USER
+const DB_PASSWORD = process.env.DB_PASSWORD
+const DB_DATABASE = process.env.DB_DATABASE
+const DB_PORT = process.env.DB_PORT
+
 const db = mysql.createPool({
-    host: '127.0.0.1',
-    user: 'user',
-    password: 'Ha@96168737',
-    database: 'user_DB',
-    port: '3306'
- })
+    connectionLimit: 100,
+    host: DB_HOST,
+    user: DB_USER,
+    password: DB_PASSWORD,
+    database: DB_DATABASE,
+    port: DB_PORT
+})
 
 // uploading file 
 


### PR DESCRIPTION
This pull request addresses the issue of hardcoded credentials in the core code by moving sensitive information, such as database credentials, into the .env file. This change ensures better security and simplifies integration for all contributors working with MySQL.

**Changes made:**
Removed hardcoded database credentials from the codebase.
Updated the configuration to fetch credentials from environment variables (.env file).

Fixed issue:
#57 

Please review the changes and ensure your local environment has the correct .env setup to avoid any integration issues.