### PR TITLE
Add toggle functionality for displaying and hiding uploaded research files

### DIFF
--- a/public/upload_file.html
+++ b/public/upload_file.html
@@ -22,7 +22,7 @@
               veniam vel illum rerum laudantium itaque vero beatae dolor, quam illo commodi omnis quibusdam repellendus
               expedita? Ab, mollitia!
             </p>
-            <div id="status" style="display: none;margin: 0;padding: 0px;;font-size: 21px;">
+            <div id="status" style="display: none; margin: 0; padding: 0px; font-size: 21px;">
               <b style="color: rgb(242, 16, 16);">File Uploaded successfully</b>
             </div>
             <label for="exampleFormControlFile1">Upload Files:</label>
@@ -36,16 +36,18 @@
       </div>
     </div>
   </section>
+
   <div id="uploadedFilesContainer">
     <h2>Uploaded Research Files</h2>
-    <button class="view" onclick="fetchUploadedFiles()">View</button>
+    <button id="viewButton" class="view" onclick="fetchUploadedFiles()">View</button>
+    <div id="uploadedFilesList" style="display: none;"></div> <!-- Container for uploaded files -->
   </div>
+
   <script>
     async function uploadFile() {
       const form = document.getElementById('uploadForm');
       const status = document.getElementById('status');
       const token = localStorage.getItem('accessToken');
-      console.log(token)
       const headers = new Headers();
       headers.append('Authorization', `Bearer ${token}`);
       const formData = new FormData(form);
@@ -60,11 +62,11 @@
           status.style.display = 'block';
           setTimeout(() => {
             status.style.display = 'none';
-          }, 2000)
-        } 
-        else if(response.status=401){ 
-          const status=document.getElementById('status')
-          status.innerHTML="You have already uploaded one Research Paper"
+          }, 2000);
+        }
+        else if (response.status === 401) {
+          status.innerHTML = "You have already uploaded one Research Paper";
+          status.style.display = 'block'; // Show error message
         }
         else {
           console.log("Failed to upload file");
@@ -74,7 +76,6 @@
         status.textContent = 'Error uploading file';
       }
     }
-
 
     async function fetchUploadedFiles() {
       const token = localStorage.getItem('accessToken');
@@ -88,27 +89,49 @@
         });
         if (response.ok) {
           const result = await response.json();
-          // console.log(result)
-          const uploadedFilesContainer = document.getElementById('uploadedFilesContainer');
+          const uploadedFilesList = document.getElementById('uploadedFilesList');
           const ul = document.createElement('ul');
-          uploadedFilesContainer.appendChild(ul);
+
+          // Clear previous list items
+          ul.innerHTML = ''; // Clear previous list items
+
           const files = result.filenames;
           const filepaths = result.filepaths;
+
+          // Loop through the files and create list items
           files.forEach((file, index) => {
             const li = document.createElement('li');
             const link = document.createElement('a');
             link.href = filepaths[index];
-            link.target="_blank"
+            link.target = "_blank";
             link.textContent = file;
             li.appendChild(link);
             ul.appendChild(li);
           });
+
+          uploadedFilesList.innerHTML = ''; // Clear previous content
+          uploadedFilesList.appendChild(ul);
+          uploadedFilesList.style.display = 'block'; // Show the list
+
+          // Change the "View" button to "Hide"
+          const viewButton = document.getElementById('viewButton');
+          viewButton.textContent = 'Hide';
+          viewButton.setAttribute('onclick', 'hideUploadedFiles()'); // Change the button's action
         } else {
           console.error('Failed to fetch uploaded files:', response.statusText);
         }
       } catch (error) {
         console.error('Error fetching uploaded files:', error);
       }
+    }
+
+    function hideUploadedFiles() {
+      const uploadedFilesList = document.getElementById('uploadedFilesList');
+      uploadedFilesList.style.display = 'none'; // Hide the list
+
+      const viewButton = document.getElementById('viewButton');
+      viewButton.textContent = 'View'; // Change the button back to "View"
+      viewButton.setAttribute('onclick', 'fetchUploadedFiles()'); // Reset the button's action
     }
   </script>
 </body>


### PR DESCRIPTION
### What does this PR do?

This PR adds functionality to toggle the visibility of the uploaded research files. 
When the user clicks 'View,' the list of uploaded files is shown, and the 'Hide' 
button replaces 'View.' Clicking 'Hide' hides the list of files and restores the 
'View' button.

### Why is this important?

Previously, the list of files would append itself every time the 'View' button was clicked, 
resulting in duplicate entries. This toggle functionality resolves that issue.

### How to test?

1. Upload a file.
2. Click 'View' to display the uploaded file list.
3. Click 'Hide' to remove the file list and return the 'View' button.

### Notes:

- [ ] Ensure that after uploading a new file, the list updates as expected without duplicates.
- Closes issue #3 
