### PR TITLE
overlapping of icons.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -774,9 +774,7 @@
             </div>
         </div>
     </footer>
-    <button id="scrollToTop" title="Back to top">
-        <i class="fa-solid fa-arrow-up"></i>
-    </button>
+   
 
     <script src="script/script.js"></script>
     <script src="script/slider.js"></script>


### PR DESCRIPTION
## 📋 Description
previously the bot and the scroll to top icons were overlapping i have solved the issue.

## 🔨 Changes Made
instead to doing the plcement of both buttons i deleted the scroll to top button as i feel it was an unnesseary feature ..the reason can seen be through the video attached.as the user can scroll upwards by using the buttons in navbar

https://github.com/user-attachments/assets/d6864945-392e-4e8b-b248-25f33f89ec69

- 
- 
- 

## ✅ Checklist

Before submitting the PR, please make sure you have completed the following:

- [x] I have followed all the guidlines mentioned in CONTRIBUTING.md.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have tested it locally and it works fine.
- [x] Any dependent changes have been merged and published in downstream modules.


- Fixes #298 

@Harshdev098  kindly review and merge my PR into the main with all the relevant tags.

