### PR TITLE
Hiding Cursor on Mobile View

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1875,6 +1875,11 @@ ul {
 
 }
 
+@media (max-width: 768px) {
+  .circle-container {
+      display: none;
+  }
+}
 
 /* Newsletter pop-up */
 


### PR DESCRIPTION
### Title : Hiding Cursor on Mobile View

Fix #369

This PR implements a solution to hide the `circle-container` on screens 768 pixels wide or smaller. The visibility is controlled using CSS media queries to enhance the mobile user experience.

@Harshdev098 
Pls give me labels like gssoc-extd, level and assign me this issue.