### PR TITLE
Added Trusted email validation functionality in news letter form

### DIFF
--- a/public/script/script.js
+++ b/public/script/script.js
@@ -269,14 +269,52 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   // Handle form submission
+    const trustedDomains = [
+      'gmail.com',
+      'outlook.com',
+      'yahoo.com',
+      'protonmail.com',
+      'icloud.com',
+      'tutanota.com',
+      'hotmail.com',
+      'live.com',
+      'mail.com',
+      'zoho.com',
+      'gmx.com',
+      'aol.com',
+      'fastmail.com',
+      'yandex.com',
+      '*.edu',          // Educational institutions
+      '*.ac.uk'         // UK universities
+  ];
+
+  function validateEmail(email) {
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Basic email format validation
+      const domain = email.split('@')[1];
+
+      return (
+          emailPattern.test(email) && 
+          trustedDomains.some((trusted) => 
+              trusted.includes('*') ? domain.endsWith(trusted.slice(1)) : domain === trusted
+          )
+      );
+  }
+
   document.getElementById('emailForm-nl').addEventListener('submit', function(event) {
       event.preventDefault();
 
-      const email = document.getElementById('email-nl').value;
+      const email = document.getElementById('email-nl').value.trim();
+
+      // Trusted email validation
+      if (!validateEmail(email)) {
+          alert('Please enter a valid email address from a trusted provider.');
+          return;
+      }
+
       if (email) {
           alert(`Your email ID ${email} has been registered successfully for the newsletter.`);
           document.getElementById('popup-nl').style.display = 'none'; // Hide the popup
-          
+
           // Set the subscribed flag in localStorage
           localStorage.setItem('subscribed', 'true');
       }
@@ -288,5 +326,3 @@ document.addEventListener('DOMContentLoaded', function() {
       document.getElementById('popup-nl').style.display = 'none';
   });
 });
-
-


### PR DESCRIPTION
### PR Description: Implemented Email Domain Validation in News Letter Form  

Fixes #366

1. Added validation to allow only trusted email domains: `gmail.com`, `outlook.com`, `yahoo.com`, `protonmail.com`, `icloud.com`, `tutanota.com`, and more.  
2. Displays an alert message if the email is from an untrusted domain and blocks submission.  
3. Ensures data integrity by filtering spam and temporary emails. 

@Harshdev098
Pls add level, gssoc-extd, hacktoberfest-accepted.