### PR TITLE
Fix Newsletter Popup Reappearance After User Dismissal

### DIFF
--- a/public/script/script.js
+++ b/public/script/script.js
@@ -320,10 +320,15 @@ document.addEventListener('DOMContentLoaded', function() {
       }
   });
 
+  if (localStorage.getItem("noThanksClicked") === "true") {
+    document.getElementById('popup-nl').style.visibility = 'hidden';
+  }
+
   // Handle "No thanks" link
   document.querySelector('.no-thanks-nl').addEventListener('click', function(event) {
-      event.preventDefault();
-      document.getElementById('popup-nl').style.display = 'none';
+    event.preventDefault();
+    document.getElementById('popup-nl').style.display = 'none';
+    localStorage.setItem("noThanksClicked", "true");
   });
 feedback
 });


### PR DESCRIPTION
# Title: Fix Newsletter Popup Reappearance After User Dismissal

## Description

Fix #394 

This PR resolves the issue of the newsletter popup reappearing after clicking **"No Thanks"** by implementing a dismissal flag in cookies/local storage. The popup now checks this flag before displaying, enhancing the user experience by preventing unnecessary prompts.

@Harshdev098 
Pls assign me this, Give me label, level.