### PR TITLE
Autofix: [BUG]: The images below About us section in home page are not "fit-to-screen"

### DIFF
--- a/public/css/main_page_style.css
+++ b/public/css/main_page_style.css
@@ -12,9 +12,17 @@
       rgba(8, 23, 82, 0.75),
       rgba(30, 2, 30, 0.75)
     ),
+    background-image: linear-gradient(
+        rgba(8, 23, 82, 0.75),
+        rgba(30, 2, 30, 0.75)
+    ),
     url("../images/calm.jpg");
   background-size: cover;
   background-position: center;
+  object-fit: cover;
+  width: 100%;
+  height: 100vh;
+    url("../images/calm.jpg");
 }
 
 .logo {


### PR DESCRIPTION
Modified the CSS for images to ensure they fit the screen for better visibility. Added object-fit property to maintain aspect ratio while filling the container. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    